### PR TITLE
Remove adding Dart SDK to PATH

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -23,11 +23,6 @@ workflows:
       events:
         - pull_request
     scripts:
-      - name: Add Dart SDK to PATH
-        script: |
-          echo PATH="$PATH":"$FLUTTER_ROOT/.pub-cache/bin" >> $CM_ENV
-          echo PATH="$PATH":"$FLUTTER_ROOT/bin" >> $CM_ENV
-
       - name: Melos Bootstrap
         script: |
           dart pub global activate melos


### PR DESCRIPTION
Adding the Dart SDK to `PATH` not needed anymore because Codemagic adds it by default since a few weeks.